### PR TITLE
Remove incorrect workaround claim for mac app notarization

### DIFF
--- a/src/app/installer/page.tsx
+++ b/src/app/installer/page.tsx
@@ -131,10 +131,6 @@ export default async function InstallerPage() {
                   Mac still experiencing issues when opening, enter settings -
                   privacy & security - scroll down - open anyway
                 </li>
-                <li>
-                  A work around for this issue is to download the asset directly
-                  from Github
-                </li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
The assets available from the website and GitHub Releases are identical (as they should be), and the Mac app for Sonoma, while it is signed by a valid developer ID cert, the signature has not been [Notarized](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution) and this is what causes the Gatekeeper error to prevent conventional opening (for both the website and github download).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Installer page release notes by removing the outdated note advising users to download assets directly from GitHub.
  - Improves clarity of on-page guidance and aligns messaging with the current process; users will no longer see the workaround note.
  - No functional or behavioral changes; app operation remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->