### PR TITLE
add tron to stats

### DIFF
--- a/src/app/getting-started/page.tsx
+++ b/src/app/getting-started/page.tsx
@@ -125,7 +125,7 @@ export default function GettingStartedPage() {
               <div className="text-sm text-foreground/70">Time to Complete</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-primary mb-1">18+ Chains</div>
+              <div className="text-2xl font-bold text-primary mb-1">19+ Chains</div>
               <div className="text-sm text-foreground/70">Supported</div>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -63,7 +63,7 @@ export default function Home() {
           {/* Key Stats */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8 bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-8">
             <div className="text-center">
-              <div className="text-2xl md:text-3xl font-bold text-primary mb-1">18+</div>
+              <div className="text-2xl md:text-3xl font-bold text-primary mb-1">19+</div>
               <div className="text-sm text-foreground/70">Blockchains</div>
             </div>
             <div className="text-center">
@@ -142,7 +142,7 @@ export default function Home() {
                   </div>
                   <h3 className="text-xl font-bold text-foreground">Multi-Chain Trading</h3>
                 </div>
-                <p className="text-foreground/80 mb-4">Cross-chain swaps across 18+ blockchains including BTC, ETH, AVAX, BSC, COSMOS, and more with real-time price discovery.</p>
+                <p className="text-foreground/80 mb-4">Cross-chain swaps across 19+ blockchains including BTC, ETH, AVAX, BSC, COSMOS, TRON, and more with real-time price discovery.</p>
                 <ul className="space-y-2 text-sm text-foreground/70">
                   <li>• Advanced trading features with trade assets</li>
                   <li>• Liquidity provision with symmetrical deposits</li>
@@ -262,7 +262,7 @@ export default function Home() {
             <h2 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold text-foreground leading-tight mb-4 sm:mb-6">
               Trade Across{' '}
               <span className="bg-gradient-primary bg-clip-text text-transparent">
-                18+ Blockchains
+                19+ Blockchains
               </span>
             </h2>
             <p className="text-base sm:text-lg md:text-xl lg:text-2xl text-foreground/80 max-w-4xl mx-auto leading-relaxed px-2">
@@ -289,7 +289,8 @@ export default function Home() {
               { name: 'Ripple', symbol: 'XRP', color: 'text-blue-500' },
               { name: 'Solana', symbol: 'SOL', color: 'text-purple-500' },
               { name: 'Base', symbol: 'BASE', color: 'text-blue-400' },
-              { name: 'Radix', symbol: 'XRD', color: 'text-green-500' }
+              { name: 'Radix', symbol: 'XRD', color: 'text-green-500' },
+              { name: 'Tron', symbol: 'TRX', color: 'text-red-500' }
             ].map((chain, index) => (
               <div key={index} className="flex flex-col items-center p-3 sm:p-4 md:p-6 rounded-xl sm:rounded-2xl bg-white/5 backdrop-blur-sm border border-white/10 hover:bg-white/10 hover:scale-105 transition-all duration-300 group">
                 <div className={`text-xl sm:text-2xl md:text-3xl font-bold ${chain.color} mb-1 sm:mb-2 group-hover:scale-110 transition-transform duration-300`}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Tron (TRX), expanding cross-chain trading to 19+ blockchains.
  - Updated supported chains grid to include Tron.
  - Refreshed UI copy to reflect the new total: hero stats, feature descriptions, and supported chains header now show “19+ Blockchains.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->