### PR TITLE
Add security headers, allowlist download URLs, swap THORChain gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Next.js 14 App Router site for the Asgardex desktop application landing page. Ty
 ### Live Metrics Widgets
 
 Three client-side widgets on the home page fetch from external APIs with 30-second polling intervals:
-- `LiveMetricsWidget.tsx` - THORChain via `midgard.ninerealms.com/v2/`
+- `LiveMetricsWidget.tsx` - THORChain via `gateway.liquify.com/chain/thorchain_midgard/v2/`
 - `LiveMayaMetricsWidget.tsx` - MayaChain via `midgard.mayachain.info/v2/`
 - `LiveChainflipMetricsWidget.tsx` - Chainflip via `chainflip-broker.io/`
 

--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,35 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 })
 
+// 'unsafe-inline' is required for script-src because Next.js App Router injects
+// inline bootstrap/hydration scripts; migrating to a nonce-based CSP would
+// require a middleware-driven request/response rewrite. Style inline is needed
+// by NextUI + Framer Motion. The policy still blocks external script loads,
+// eval, and restricts where the page can fetch/frame/submit to.
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://gateway.liquify.com https://midgard.mayachain.info https://reporting-service.chainflip.io",
+  "frame-ancestors 'none'",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  'upgrade-insecure-requests',
+].join('; ')
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: contentSecurityPolicy },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' },
+]
+
 const nextConfig = {
   experimental: {
     optimizePackageImports: ['@nextui-org/react', 'framer-motion', 'react-icons'],
@@ -19,6 +48,14 @@ const nextConfig = {
   swcMinify: true,
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production',
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
   },
 }
 

--- a/src/app/lib/api.tsx
+++ b/src/app/lib/api.tsx
@@ -101,6 +101,20 @@ function extractReleaseSummary(body: string): string {
   }
 }
 
+// Only URLs under this prefix are safe to render as downloads. Anything else
+// — a `javascript:` URL, an unexpected host, or a protocol-relative value —
+// is replaced with the static releases page so a tampered releases.json
+// cannot point users at an attacker-controlled binary.
+const TRUSTED_DOWNLOAD_PREFIX = 'https://github.com/asgardex/'
+const RELEASES_FALLBACK_URL = 'https://github.com/asgardex/asgardex-desktop/releases'
+
+function safeDownloadUrl(url: string | undefined | null): string {
+  if (typeof url === 'string' && url.startsWith(TRUSTED_DOWNLOAD_PREFIX)) {
+    return url
+  }
+  return RELEASES_FALLBACK_URL
+}
+
 // Dynamically import releases to reduce initial bundle size
 async function loadReleases(): Promise<Release[]> {
   try {
@@ -114,7 +128,8 @@ async function loadReleases(): Promise<Release[]> {
 
 const buildReleaseItem = (releaseItem: Release) => {
   const baseTitle = releaseItem.tag_name || 'Unknown'
-  const defaultAsset = { browser_download_url: releaseItem.html_url, title: baseTitle }
+  const htmlUrl = safeDownloadUrl(releaseItem.html_url)
+  const defaultAsset = { browser_download_url: htmlUrl, title: baseTitle }
 
   const linuxAsset = releaseItem.assets.find((asset) =>
     asset.browser_download_url.endsWith('.AppImage')
@@ -137,28 +152,28 @@ const buildReleaseItem = (releaseItem: Release) => {
 
   return {
     tag_name: baseTitle,
-    html_url: releaseItem.html_url,
+    html_url: htmlUrl,
     body: releaseItem.body,
     summary: extractReleaseSummary(releaseItem.body),
     linux: {
       title: baseTitle,
-      url: linuxAsset.browser_download_url
+      url: safeDownloadUrl(linuxAsset.browser_download_url)
     },
     macSon: {
       title: `Sonoma - ${baseTitle}`,
-      url: macAssetSon.browser_download_url
+      url: safeDownloadUrl(macAssetSon.browser_download_url)
     },
     macVent: {
       title: `Ventura - ${baseTitle}`,
-      url: macAssetVent.browser_download_url
+      url: safeDownloadUrl(macAssetVent.browser_download_url)
     },
     macSequ: {
       title: `Sequoia - ${baseTitle}`,
-      url: macAssetSequ.browser_download_url
+      url: safeDownloadUrl(macAssetSequ.browser_download_url)
     },
     windows: {
       title: baseTitle,
-      url: windowsAsset.browser_download_url
+      url: safeDownloadUrl(windowsAsset.browser_download_url)
     }
   }
 }

--- a/src/app/ui/LiveMetricsWidget.tsx
+++ b/src/app/ui/LiveMetricsWidget.tsx
@@ -57,9 +57,9 @@ interface NetworkApiData {
 export default function LiveMetricsWidget() {
   const fetchMetrics = useCallback(async (signal: AbortSignal): Promise<ThorchainMetrics> => {
     const [networkResponse, poolsResponse, statsResponse] = await Promise.all([
-      fetch('https://midgard.ninerealms.com/v2/network', { signal }),
-      fetch('https://midgard.ninerealms.com/v2/pools', { signal }),
-      fetch('https://midgard.ninerealms.com/v2/stats', { signal })
+      fetch('https://gateway.liquify.com/chain/thorchain_midgard/v2/network', { signal }),
+      fetch('https://gateway.liquify.com/chain/thorchain_midgard/v2/pools', { signal }),
+      fetch('https://gateway.liquify.com/chain/thorchain_midgard/v2/stats', { signal })
     ])
 
     if (!networkResponse.ok) throw new Error(`Network API error: ${networkResponse.status}`)


### PR DESCRIPTION
- next.config.js: add CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy via headers() to reduce XSS blast radius and lock down connect/frame/form destinations.
- src/app/lib/api.tsx: validate every URL from releases.json against https://github.com/asgardex/, falling back to the static releases page so a tampered JSON cannot point users at an attacker-controlled binary.
- src/app/ui/LiveMetricsWidget.tsx: swap midgard.ninerealms.com for gateway.liquify.com/chain/thorchain_midgard; CSP connect-src updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added HTTP response headers (Content-Security-Policy, HSTS, X-Frame-Options, Permissions-Policy) to all application routes for enhanced protection
  * Implemented URL validation for download links to ensure all downloads come from trusted sources only

* **Infrastructure**
  * Updated live metrics widget data endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->