### PR TITLE
feat: link Arch AUR package on Linux downloads

### DIFF
--- a/src/app/getting-started/page.tsx
+++ b/src/app/getting-started/page.tsx
@@ -20,13 +20,14 @@ const steps = [
     id: 2,
     title: 'Install & Launch',
     description: 'Follow the installation steps for your platform',
-    content: "Run the downloaded file to install AsgardEX. On Windows, launch the .exe installer; if SmartScreen warns, click 'More info' then 'Run anyway' as the app is digitally signed. On macOS, open the .dmg and drag AsgardEX to Applications; if Gatekeeper blocks it, allow the app under System Settings > Privacy & Security. On Linux, either make the AppImage executable and run it, or install the Flatpak build.",
+    content: "Run the downloaded file to install AsgardEX. On Windows, launch the .exe installer; if SmartScreen warns, click 'More info' then 'Run anyway' as the app is digitally signed. On macOS, open the .dmg and drag AsgardEX to Applications; if Gatekeeper blocks it, allow the app under System Settings > Privacy & Security. On Linux, use the AppImage, Flatpak, or the community AUR package on Arch.",
     screenshot: '/getting-started/installation-wizard.png',
     tips: [
       "Windows: click 'More info' then 'Run anyway' if SmartScreen blocks the signed installer",
       "macOS: right-click the app and choose 'Open' if Gatekeeper blocks it the first time",
       'Linux (AppImage): run chmod +x ASGARDEX-*.AppImage, then launch it with ./ASGARDEX-*.AppImage',
       'Linux (Flatpak): install with flatpak install --user ASGARDEX-*.flatpak, then start it from your applications menu (requires Flatpak installed)',
+      'Linux (Arch/AUR): yay -S asgardex-appimage (community-maintained package of the official AppImage)',
       'Make sure you have the necessary permissions to install applications'
     ]
   },

--- a/src/app/installer/page.tsx
+++ b/src/app/installer/page.tsx
@@ -176,16 +176,28 @@ export default async function InstallerPage() {
                 <IconDownload size={14} className="mr-1 sm:mr-2 sm:w-4 sm:h-4 md:w-5 md:h-5" />
                 Download for Linux
               </Button>
-              {latest?.linuxFlatpak?.url && (
+              <div className="flex gap-2 mb-2 sm:mb-3 md:mb-4">
+                {latest?.linuxFlatpak?.url && (
+                  <Button
+                    as={Link}
+                    href={latest.linuxFlatpak.url}
+                    size="sm"
+                    variant="bordered"
+                    className="flex-1 text-xs">
+                    Flatpak
+                  </Button>
+                )}
                 <Button
                   as={Link}
-                  href={latest.linuxFlatpak.url}
+                  href="https://aur.archlinux.org/packages/asgardex-appimage"
                   size="sm"
                   variant="bordered"
-                  className="w-full text-xs mb-2 sm:mb-3 md:mb-4">
-                  Flatpak
+                  className="flex-1 text-xs"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Arch (AUR)
                 </Button>
-              )}
+              </div>
               {previous && (
                 <Selector label="Previous Versions" items={previous.linux} />
               )}
@@ -450,10 +462,19 @@ export default async function InstallerPage() {
                 <div>
                   <h3 className="text-base sm:text-lg font-bold text-foreground mb-2 sm:mb-3">How do I run AsgardEX on Linux?</h3>
                   <p className="text-foreground/80 text-xs sm:text-sm leading-relaxed">
-                    Two builds are available. The AppImage is portable and needs no installation &mdash; make it
+                    Three options are available. The AppImage is portable and needs no installation &mdash; make it
                     executable with <span className="font-mono">chmod +x ASGARDEX-*.AppImage</span> and run it directly.
                     The Flatpak integrates with your desktop &mdash; install it with <span className="font-mono">flatpak
                     install --user ASGARDEX-*.flatpak</span> (requires Flatpak) and launch it from your applications menu.
+                    Arch Linux users can install the community-maintained{' '}
+                    <Link
+                      href="https://aur.archlinux.org/packages/asgardex-appimage"
+                      className="text-primary underline underline-offset-2 hover:opacity-80"
+                      target="_blank"
+                      rel="noopener noreferrer">
+                      asgardex-appimage
+                    </Link>
+                    {' '}package from the AUR (for example with <span className="font-mono">yay -S asgardex-appimage</span>).
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Add a secondary **Arch (AUR)** control next to Flatpak on the installer Linux card
- Document the community `asgardex-appimage` package in the Linux FAQ and getting-started tips
- Closes #166

## Notes
- Reimplemented from #178 on a branch in this repo so Vercel preview deploys can run (fork PR from external contributor requires team authorization)
- AUR package is community-maintained (not an official Asgardex package)
- Primary Linux CTA remains the official AppImage download

## Test plan
- [ ] Open `/installer` and confirm Linux card shows Flatpak + Arch (AUR) secondary buttons
- [ ] AUR button opens https://aur.archlinux.org/packages/asgardex-appimage in a new tab
- [ ] Linux FAQ mentions AppImage, Flatpak, and AUR install example
- [ ] Getting-started install tips include the AUR line
- [ ] Mobile layout still looks fine with the two secondary buttons side by side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Flatpak and Arch/AUR installation options to the Linux download section.
  * Added conditional Flatpak availability and a direct Arch/AUR package link.
  * Expanded Linux installation guidance with AppImage, Flatpak, and Arch/AUR instructions.
* **Documentation**
  * Updated the getting-started guide and Linux FAQ with clearer installation steps and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->