### PR TITLE
feat: clarify Linux download formats (AppImage, Deb, Flatpak)

### DIFF
--- a/src/app/getting-started/page.tsx
+++ b/src/app/getting-started/page.tsx
@@ -20,12 +20,13 @@ const steps = [
     id: 2,
     title: 'Install & Launch',
     description: 'Follow the installation steps for your platform',
-    content: "Run the downloaded file to install AsgardEX. On Windows, launch the .exe installer; if SmartScreen warns, click 'More info' then 'Run anyway' as the app is digitally signed. On macOS, open the .dmg and drag AsgardEX to Applications; if Gatekeeper blocks it, allow the app under System Settings > Privacy & Security. On Linux, use the AppImage, Flatpak, or the community AUR package on Arch.",
+    content: "Run the downloaded file to install AsgardEX. On Windows, launch the .exe installer; if SmartScreen warns, click 'More info' then 'Run anyway' as the app is digitally signed. On macOS, open the .dmg and drag AsgardEX to Applications; if Gatekeeper blocks it, allow the app under System Settings > Privacy & Security. On Linux, use the AppImage, Deb, Flatpak, or the community AUR package on Arch.",
     screenshot: '/getting-started/installation-wizard.png',
     tips: [
       "Windows: click 'More info' then 'Run anyway' if SmartScreen blocks the signed installer",
       "macOS: right-click the app and choose 'Open' if Gatekeeper blocks it the first time",
       'Linux (AppImage): run chmod +x ASGARDEX-*.AppImage, then launch it with ./ASGARDEX-*.AppImage',
+      'Linux (Deb): install with sudo dpkg -i ASGARDEX-*.deb on Debian/Ubuntu (or open the .deb in your package manager)',
       'Linux (Flatpak): install with flatpak install --user ASGARDEX-*.flatpak, then start it from your applications menu (requires Flatpak installed)',
       'Linux (Arch/AUR): yay -S asgardex-appimage (community-maintained package of the official AppImage)',
       'Make sure you have the necessary permissions to install applications'

--- a/src/app/installer/page.tsx
+++ b/src/app/installer/page.tsx
@@ -11,6 +11,7 @@ interface ReleaseItem {
   body: string
   summary: string
   linux: { title: string, url: string }
+  linuxDeb: { title: string, url: string }
   linuxFlatpak: { title: string, url: string }
   macSon: { title: string, url: string }
   macVent: { title: string, url: string }
@@ -164,7 +165,7 @@ export default async function InstallerPage() {
                 />
               </div>
               <h3 className="text-base sm:text-lg md:text-xl font-bold text-foreground mb-1 sm:mb-2">Linux</h3>
-              <p className="text-xs sm:text-sm md:text-base text-foreground/70 mb-2 sm:mb-3 md:mb-4">Ubuntu 18.04 or later</p>
+              <p className="text-xs sm:text-sm md:text-base text-foreground/70 mb-2 sm:mb-3 md:mb-4">AppImage, Deb &amp; Flatpak</p>
               {latest && (
                 <p className="text-xs sm:text-sm text-foreground/60 mb-3 sm:mb-4 md:mb-6">Version {latest.tag_name}</p>
               )}
@@ -174,16 +175,26 @@ export default async function InstallerPage() {
                 href={latest?.linux?.url || latest?.html_url || '#'}
                 className="w-full mb-2 sm:mb-3 md:mb-4 bg-gradient-primary text-primary-foreground px-3 sm:px-4 md:px-6 py-2 sm:py-3 text-xs sm:text-sm md:text-base font-bold rounded-lg hover:shadow-glow hover:scale-105 transition-all duration-300">
                 <IconDownload size={14} className="mr-1 sm:mr-2 sm:w-4 sm:h-4 md:w-5 md:h-5" />
-                Download for Linux
+                Download AppImage
               </Button>
-              <div className="flex gap-2 mb-2 sm:mb-3 md:mb-4">
+              <div className="flex flex-wrap gap-2 mb-2 sm:mb-3 md:mb-4">
+                {latest?.linuxDeb?.url && (
+                  <Button
+                    as={Link}
+                    href={latest.linuxDeb.url}
+                    size="sm"
+                    variant="bordered"
+                    className="flex-1 min-w-[4.5rem] text-xs">
+                    Deb
+                  </Button>
+                )}
                 {latest?.linuxFlatpak?.url && (
                   <Button
                     as={Link}
                     href={latest.linuxFlatpak.url}
                     size="sm"
                     variant="bordered"
-                    className="flex-1 text-xs">
+                    className="flex-1 min-w-[4.5rem] text-xs">
                     Flatpak
                   </Button>
                 )}
@@ -192,7 +203,7 @@ export default async function InstallerPage() {
                   href="https://aur.archlinux.org/packages/asgardex-appimage"
                   size="sm"
                   variant="bordered"
-                  className="flex-1 text-xs"
+                  className="flex-1 min-w-[4.5rem] text-xs"
                   target="_blank"
                   rel="noopener noreferrer">
                   Arch (AUR)
@@ -462,8 +473,10 @@ export default async function InstallerPage() {
                 <div>
                   <h3 className="text-base sm:text-lg font-bold text-foreground mb-2 sm:mb-3">How do I run AsgardEX on Linux?</h3>
                   <p className="text-foreground/80 text-xs sm:text-sm leading-relaxed">
-                    Three options are available. The AppImage is portable and needs no installation &mdash; make it
+                    Several options are available. The AppImage is portable and needs no installation &mdash; make it
                     executable with <span className="font-mono">chmod +x ASGARDEX-*.AppImage</span> and run it directly.
+                    Debian/Ubuntu users can install the <span className="font-mono">.deb</span> package with{' '}
+                    <span className="font-mono">sudo dpkg -i ASGARDEX-*.deb</span> (or open it in their package manager).
                     The Flatpak integrates with your desktop &mdash; install it with <span className="font-mono">flatpak
                     install --user ASGARDEX-*.flatpak</span> (requires Flatpak) and launch it from your applications menu.
                     Arch Linux users can install the community-maintained{' '}

--- a/src/app/lib/api.tsx
+++ b/src/app/lib/api.tsx
@@ -134,6 +134,9 @@ const buildReleaseItem = (releaseItem: Release) => {
   const linuxAsset = releaseItem.assets.find((asset) =>
     asset.browser_download_url.endsWith('.AppImage')
   ) || defaultAsset
+  const linuxDebAsset = releaseItem.assets.find((asset) =>
+    asset.browser_download_url.endsWith('.deb')
+  )
   const linuxFlatpakAsset = releaseItem.assets.find((asset) =>
     asset.browser_download_url.endsWith('.flatpak')
   )
@@ -161,9 +164,15 @@ const buildReleaseItem = (releaseItem: Release) => {
     html_url: htmlUrl,
     body: releaseItem.body,
     summary: extractReleaseSummary(releaseItem.body),
+    // Primary Linux download is the portable AppImage (works across distros).
     linux: {
       title: baseTitle,
       url: safeDownloadUrl(linuxAsset.browser_download_url)
+    },
+    // .deb is published for Debian/Ubuntu-family installs; hide when missing.
+    linuxDeb: {
+      title: baseTitle,
+      url: linuxDebAsset ? safeDownloadUrl(linuxDebAsset.browser_download_url) : ''
     },
     // Flatpak is only present from v1.45.0 onward; older releases leave this
     // empty so the download page can hide the option rather than link to a
@@ -217,6 +226,7 @@ export async function getAsgardexReleases() {
         body: '',
         summary: 'Latest features and improvements',
         linux: { title: '', url: '' },
+        linuxDeb: { title: '', url: '' },
         linuxFlatpak: { title: '', url: '' },
         macSon: { title: '', url: '' },
         macVent: { title: '', url: '' },


### PR DESCRIPTION
## Summary
- Rename the primary Linux CTA from **Download for Linux** to **Download AppImage** (still the portable default)
- Add a secondary **Deb** button for the official `.deb` release asset
- Update the Linux card subtitle to **AppImage, Deb & Flatpak**
- Document Deb install steps in the installer FAQ and getting-started tips

## Notes
- AppImage remains the primary download (works across distros)
- Deb/Flatpak buttons only render when the release includes those assets
- Arch (AUR) secondary link is unchanged

## Test plan
- [ ] Open `/installer` and confirm primary button says **Download AppImage** and downloads the `.AppImage`
- [ ] Confirm secondary row shows **Deb**, **Flatpak**, and **Arch (AUR)**
- [ ] Deb button downloads `ASGARDEX-*-linux.deb` from the latest release
- [ ] Linux FAQ mentions AppImage, Deb, Flatpak, and AUR
- [ ] Getting-started install tips include the Deb line
- [ ] Mobile layout still looks fine with three secondary buttons